### PR TITLE
feature: make local context optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ dist
 .tern-port
 
 .DS_Store
+
+components/uitest/*.png
+components/uitest/.*

--- a/components/component-return.html
+++ b/components/component-return.html
@@ -2,19 +2,83 @@
 			******* COMPONENT RETURN *************
 -->
 <script type="text/javascript">
-	const findStartNode = function (returnNodeId) {
-		let startNode = undefined
-		Object.values(RED.nodes.originalFlow()).forEach(n => {
-			if (n.type == "component_in") {
-				let foundList = {}
-				findReturnNodes(n.id, foundList)
-				if (foundList[returnNodeId]) {
-					startNode = n
+	const findStartNodes = function (nodeId, sources = {}, visited = [], found = []) {
+		if (visited.includes(nodeId)) {
+			return sources;
+		}
+		visited.push(nodeId);
+		let node = RED.nodes.node(nodeId);
+		if (node.type == "component_in") {
+			found.push(nodeId);
+		}
+		RED.nodes.eachLink((link) => {
+			if (link.target.id == nodeId) {
+				sources[link.source.id] = {};
+				findStartNodes(link.source.id, sources[link.source.id], visited, found);
+			}
+		});
+		if (node.type == "link in") {
+			let linkOuts = node.links;
+			for (let lout of linkOuts) {
+				sources[lout] = {};
+				findStartNodes(lout, sources[lout], visited, found);
+			};
+		}
+		return found;
+	};
+
+	const MSG_NOT_CONNECTED = "node is not connected";
+	const MSG_TOO_MANY_START_NODES = "node is connected to multiple start nodes";
+
+	const doValidate = function (val) {
+		let node = val;
+		if (typeof (val) != "object") {
+			node = RED.nodes.node(this.id);
+		}
+		if (!node.validationErrors) {
+			node.validationErrors = [];
+		}
+		let startNodes = findStartNodes(node.id);
+		if (startNodes.length == 0) {
+			if (!node.validationErrors.includes(MSG_NOT_CONNECTED)) {
+				node.validationErrors.push(MSG_NOT_CONNECTED);
+				node.change = true;
+				RED.view.redraw(node);
+			}
+		} else if (startNodes.length > 1) {
+			if (!node.validationErrors.includes(MSG_TOO_MANY_START_NODES)) {
+				node.validationErrors.push(MSG_TOO_MANY_START_NODES);
+				node.change = true;
+				RED.view.redraw(node);
+			}
+		} else {
+			if (node.validationErrors.includes(MSG_NOT_CONNECTED)) {
+				const index = node.validationErrors.indexOf(MSG_NOT_CONNECTED);
+				if (index > -1) {
+					node.validationErrors.splice(index, 1);
+					node.change = true;
+					RED.view.redraw(node);
 				}
 			}
-		})
-		return startNode
+			if (node.validationErrors.includes(MSG_TOO_MANY_START_NODES)) {
+				const index = node.validationErrors.indexOf(MSG_TOO_MANY_START_NODES);
+				if (index > -1) {
+					node.validationErrors.splice(index, 1);
+					node.change = true;
+					RED.view.redraw(node);
+				}
+			}
+		}
+		node.valid = node.validationErrors.length == 0;
+		return node.valid;
 	}
+
+	const handlerX = function (event) {
+		if (event.node.type == "component_out") {
+			doValidate(event.node)
+		}
+	};
+	RED.hooks.add("viewRedrawNode", handlerX);
 
 	RED.nodes.registerType('component_out', {
 		category: COMPONENTS_CATEGORY,
@@ -28,14 +92,8 @@
 		},
 		align: 'right',
 		defaults: {
-			name: { value: null },
+			name: { value: null, validate: doValidate },
 			mode: { value: "default" },
-			node_is_not_connected: {
-				value: false, validate: function (v) {
-					let myStartNode = findStartNode(this.id)
-					return myStartNode !== undefined
-				}
-			},
 			component_definitions_are_NOT_allowed_inside_subflows: {
 				value: false, validate: function (v) {
 					return !RED.nodes.subflow(this.z)

--- a/components/component-start.html
+++ b/components/component-start.html
@@ -68,15 +68,7 @@
 		defaults: {
 			name: { value: "component in" },
 			api: { value: [{ name: "prop", type: "string" }] },
-			node_is_not_connected: {
-				value: false, validate: function (v) {
-					// check if we have at least one node connected. Might be a "no-return" config
-					let node = RED.nodes.originalFlow().find((node) => {
-						return node.id == this.id;
-					});
-					return node.wires[0].length > 0
-				}
-			},
+			usecontext: { value: false },
 			component_definitions_are_NOT_allowed_inside_subflows: {
 				value: RED.nodes.subflow(this.z), validate: function (v) {
 					return !RED.nodes.subflow(this.z)
@@ -103,12 +95,24 @@
 					$(".valid").show()
 					$(".invalid").hide()
 
+					// context mode
+					let usecontext = this.usecontext || false;
+					let cbContext = $("#node-input-usecontext");
+					cbContext.prop("checked", usecontext);
+					cbContext.on("click", function () {
+						if (cbContext.prop("checked")) {
+							$(".contextoption").show();
+						} else {
+							$(".contextoption").hide();
+						}
+					});
+
 					let i18n = this._;
 					function resizeRule(item) {
 						// not used yet
 					}
 					$('#node-input-api-container').css('min-height', '250px').css('min-width', '450px').editableList({
-						addItem: function (container, i, property) {
+						addItem: function (container, index, property) {
 							if (!property.type) {
 								// empty, new item
 								property.type = "any";
@@ -131,16 +135,23 @@
 							var checkBoxes = $('<div>', { style: "flex: 0 0 min-content; display: flex; flex-direction: column" }).appendTo(row1);
 
 							var checkRow1 = $('<div>', { style: "flex: 0 0 min-content; display: flex; align-items: top" }).appendTo(checkBoxes);
-							var required = $('<input/>', { id: "cb_required_" + i, class: "node-input-property-required", type: "checkbox", style: "flex: 1;" }).appendTo(checkRow1);
-							$('<label/>', { text: i18n("components.label.required"), 'for': 'cb_required_' + i, style: "flex: 2;" }).appendTo(checkRow1);
-							var global = $('<input/>', { id: "cb_globaL_" + i, class: "node-input-property-global", type: "checkbox", style: "flex: 1;" }).appendTo(checkRow1);
-							$('<label/>', { text: i18n("components.label.global"), 'for': 'cb_globaL_' + i, style: "flex: 2;" }).appendTo(checkRow1);
+							var required = $('<input/>', { id: "cb_required_" + index, class: "node-input-property-required", type: "checkbox", style: "flex: 1;" }).appendTo(checkRow1);
+							$('<label/>', { text: i18n("components.label.required"), 'for': 'cb_required_' + index, style: "flex: 2;" }).appendTo(checkRow1);
+							var context = $('<input/>', { id: "cb_context_" + index, class: "node-input-property-contextoption contextoption", type: "checkbox", style: "flex: 1;" }).appendTo(checkRow1);
+							var contextLabel = $('<label/>', { text: i18n("components.label.context_local"), 'for': 'cb_context_' + index, style: "flex: 2;", class: "contextoption" }).appendTo(checkRow1);
+							if (usecontext) {
+								context.show();
+								contextLabel.show();
+							} else {
+								context.hide();
+								contextLabel.hide();
+							}
 
 							propertyName.val(property.name);
 							selectField.val(property.type);
 							required.prop("checked", property.required);
-							global.prop("checked", property.global);
-							// validate.prop("checked", property.validate);
+							context.prop("checked", property.contextOption); // TODO handle legacy property.global from 0.2.2 / 0.2.3
+
 							resizeRule(container);
 						},
 						resizeItem: resizeRule,
@@ -158,6 +169,7 @@
 						var prop = this.api[i];
 						$("#node-input-api-container").editableList('addItem', prop);
 					}
+
 				}
 
 			} catch (err) {
@@ -174,8 +186,8 @@
 				var name = property.find(".node-input-property-name").val();
 				var type = property.find(".node-input-property-type").val();
 				var required = property.find(".node-input-property-required")[0].checked;
-				var global = property.find(".node-input-property-global")[0].checked;
-				node.api.push({ name, type, required, global });
+				var contextOption = property.find(".node-input-property-contextoption")[0].checked;
+				node.api.push({ name, type, required, contextOption });
 			});
 		}
 	});
@@ -189,6 +201,11 @@
         <label for="node-input-name" data-i18n="components.label.name"><i class="icon-tag"></i></label>
         <input type="text" id="node-input-name" data-i18n="[placeholder]components.label.name">
     </div>
+	<div class="form-row">
+		<label></label>
+		<input id="node-input-usecontext" type="checkbox" style="margin-left:0px; vertical-align:top; width:auto !important;"></input>
+		<label for="node-input-usecontext" style="width:auto !important;" data-i18n="components.label.usecontext"></label>
+	</div>
 	<div class="form-row valid" style="margin-bottom:0;">
         <label data-i18n="components.label.api"><i class="fa fa-list"></i> </label>
     </div>

--- a/components/component-start.html
+++ b/components/component-start.html
@@ -139,7 +139,7 @@
 							propertyName.val(property.name);
 							selectField.val(property.type);
 							required.prop("checked", property.required);
-							required.prop("checked", property.global);
+							global.prop("checked", property.global);
 							// validate.prop("checked", property.validate);
 							resizeRule(container);
 						},

--- a/components/component-start.js
+++ b/components/component-start.js
@@ -72,6 +72,9 @@ module.exports = function (RED) {
     RED.nodes.createNode(this, config);
     var node = this;
 
+    node.usecontext = config.usecontext || false;
+    node.api = config.api; // keep in the node to let RUN nodes find it at runtime (after changes in START only)
+
     var startFlowHandler = function (msg) {
       try {
         if (isInvalidInSubflow(RED, node) == true) {

--- a/components/locales/de/component-start.json
+++ b/components/locales/de/component-start.json
@@ -13,7 +13,8 @@
             },
             "outportChange": "Achtung",
             "componentInSubflow": "Nicht erlaubt in Subflows",
-            "global": "global"
+            "usecontext": "Use local context",
+            "context_local": "local"
         },
         "message": {
             "invalid_comp": "Komponente '__nodeId__' empfing inkorrektes Event. 'msg._comp' ist 'undefined' oder 'null'",

--- a/components/locales/de/run-component.json
+++ b/components/locales/de/run-component.json
@@ -12,8 +12,7 @@
                 "separate": "Einzel"
             },
             "outportChange": "Achtung",
-            "componentInSubflow": "Nicht erlaubt in Subflows",
-            "global": "global"
+            "componentInSubflow": "Nicht erlaubt in Subflows"
         },
         "message": {
             "invalid_comp": "Komponente '__nodeId__' empfing inkorrektes Event. 'msg._comp' ist 'undefined' oder 'null'",
@@ -22,6 +21,7 @@
             "lastCaller": "letzter Aufruf von",
             "missingProperty": "Parameter '__parameter__' wird erwartet, hat aber keinen Wert.",
             "running": "läuft",
+            "hasValidationErrors": "Ungültige Parameter",
             "validationError": "Ungültiger Parameter '__parameter__'. Erwartet: '__expected__', Empfangen: '__invalidType__'. Wert: '__value__'.",
             "jsonValidationError": "Ungültiger Parameter '__parameter__'. Wert konnte nicht als JSON validiert werden: '__value__'.",
             "outportChange": "Die Output Ports haben sich geändert. Bitte diesen Dialog speichern, um die Anzahl und Bezeichnung der Ports zu aktualisieren.",

--- a/components/locales/en-US/component-start.json
+++ b/components/locales/en-US/component-start.json
@@ -13,7 +13,8 @@
             },
             "outportChange": "Attention",
             "componentInSubflow": "Not allowed inside subflows",
-            "global": "global"
+            "usecontext": "Use local context",
+            "context_local": "local"
         },
         "message": {
             "invalid_comp": "component '__nodeId__' received invalid event. 'msg._comp' is 'undefined' or 'null'",

--- a/components/locales/en-US/run-component.json
+++ b/components/locales/en-US/run-component.json
@@ -12,8 +12,7 @@
                 "separate": "Separate"
             },
             "outportChange": "Attention",
-            "componentInSubflow": "Not allowed inside subflows",
-            "global": "global"
+            "componentInSubflow": "Not allowed inside subflows"
         },
         "message": {
             "invalid_comp": "component '__nodeId__' received invalid event. 'msg._comp' is 'undefined' or 'null'",
@@ -22,6 +21,7 @@
             "lastCaller": "last caller",
             "missingProperty": "component parameter '__parameter__' is required, but no value was found.",
             "running": "running",
+            "hasValidationErrors": "Invalid Parameters",
             "validationError": "invalid parameter '__parameter__'. Expected type '__expected__', current type '__invalidType__'. Value is '__value__'.",
             "jsonValidationError": "invalid parameter '__parameter__': Value is not a valid JSON: '__value__'.",
             "outportChange": "Output ports have changed. Please save this Dialog to synchronize the number and labels.",

--- a/components/run-component.html
+++ b/components/run-component.html
@@ -6,39 +6,94 @@
 		category: COMPONENTS_CATEGORY,
 		color: COMPONENTS_COLOR,
 		label: function () {
-			return this.name || (this.targetComponent ? "-> " + this.targetComponent.name : false) || "run ???";
+			let targetComponent;
+			if (this.targetComponentId) {
+				targetComponent = RED.nodes.node(this.targetComponentId);
+			}
+			if (!targetComponent) {
+				if (this.targetComponent && this.targetComponent.id) {
+					targetComponent = RED.nodes.node(this.targetComponent.id);
+				}
+			}
+			return this.name ||
+				(targetComponent ? "-> " + targetComponent.name : false) ||
+				"run ???";
 		},
 		defaults: {
 			name: { value: "" },
 			targetComponent: {
-				value: null, required: true, validate: function (val) {
-					if (val && val.id) {
-						// check if target exists (might by stale)
-						if (RED.nodes.node(val.id)) return true
+				// legacy since 0.2.4
+				value: null
+			},
+			targetComponentId: {
+				value: null, validate: function (val) {
+					if (val) {
+						// check if target exists (might be stale)
+						if (RED.nodes.node(val)) return true
+					}
+					if (this.targetComponent && this.targetComponent.id) {
+						// check if target exists (might be stale)
+						if (RED.nodes.node(this.targetComponent.id)) return true
 					}
 					return false
 				}
 			},
 			paramSources: {
 				value: {}, validate: function (val) {
+					let targetComponentId = this.targetComponentId;
+					// check legacy
+					if (!targetComponentId && this.targetComponent && this.targetComponent.id) {
+						targetComponentId = this.targetComponent.id;
+					}
+					let targetComponent = RED.nodes.node(targetComponentId);
+					if (!targetComponent) {
+						// ??? could only happen, if START node was deleted and this property is validated before this.targetComponentId
+						// in that case we just ignore it and wait for validation of this.targetComponentId
+						return true; // basically means we don't further validate.
+					}
+					// first check, if we are missing a parameter from the api
+					let apiByName = {};
+					for (let p in targetComponent.api) {
+						let paramDef = targetComponent.api[p];
+						apiByName[paramDef.name] = paramDef;
+						let found = false;
+						for (let p in val) {
+							let param = val[p];
+							if (param.name == paramDef.name) {
+								found = true;
+							}
+						}
+						if (!found) {
+							console.log("validate error", this.id, "did not find a paramSource for api param", paramDef.name);
+							return false;
+						}
+					}
 					for (let p in val) {
 						let param = val[p]
+						let paramDef = apiByName[param.name];
+						if (!paramDef) {
+							// got no def, so this source is stale.
+							continue; // we ignore that, as the paramSource will vanish on Save.
+						}
 						let v = param.source
 						switch (param.sourceType) {
 							case "str": {
 								if (typeof v == "object") {
+									console.log("validate error", this.id, "param", "'" + param.name + "'", "expecting 'string', but got 'object'");
 									return false
 								}
 								break;
 							}
 							case "bool": {
 								if (v === null || v === undefined || v.length == 0 || (v !== 'true' && v !== 'false')) {
+									console.log("validate error", this.id, "param", "'" + param.name + "'", "expecting valid 'boolean', but got", v);
 									return false
 								}
 								break;
 							}
 							case "num": {
 								if (v === null || v === undefined || v.length == 0 || isNaN(parseFloat(v))) {
+									console.log("validate error", this.id, "param", "'" + param.name + "'", "expecting valid 'number', but got", v);
 									return false
 								}
 								break;
@@ -47,6 +102,7 @@
 							case "flow":
 							case "global": {
 								if (v === null || v === undefined || v.length == 0) {
+									console.log("validate error", this.id, "param", "'" + param.name + "'", "expecting input, but got", v);
 									return false
 								}
 								break;
@@ -58,17 +114,20 @@
 								try {
 									jsonata(v)
 								} catch (err) {
+									console.log("validate error", this.id, "param", "'" + param.name + "'", "expecting valid jsonata expression, but parsing failed", v, err);
 									return false
 								}
 								break;
 							}
 							case "json": {
 								if (v === null || v === undefined || v.length == 0) {
+									console.log("validate error", this.id, "param", "'" + param.name + "'", "expecting json expression, but got", v);
 									return false
 								}
 								try {
 									JSON.parse(v)
 								} catch (err) {
+									console.log("validate error", this.id, "param", "'" + param.name + "'", "expecting valid json expression, but parsing failed", v, err);
 									return false
 								}
 								break;
@@ -107,9 +166,9 @@
 
 				let config = this;
 
-				let updateParameters = function (compStartNode, paramSources) {
+				let updateParameters = function (targetComponentNode, paramSources) {
 					$("#node-input-parameter-container").editableList('empty');
-					let api = compStartNode.api;
+					let api = targetComponentNode.api;
 					for (var i = 0; i < api.length; i++) {
 						var param = $.extend({}, api[i]);
 						if (paramSources) {
@@ -123,9 +182,8 @@
 					}
 				}
 
-				let setLinkToDefinition = function (config, target) {
-					if (target) {
-						// $("#node-appname-message").text(config._("components/"));
+				let setLinkToDefinition = function (config, targetComponentId) {
+					if (targetComponentId) {
 						$("#node-jumplink").replaceWith(' <a id="node-jumplink" href="#"><b>Jump to node</b></a>');
 						$("#node-jumplink").on("click", function () {
 							// show webappNode in editor
@@ -136,9 +194,20 @@
 					}
 				}
 
-				// link to START node
-				setLinkToDefinition(config, config.targetComponent);
+				// find target component
+				let targetComponentId = config.targetComponentId;
+				// legacy since 0.2.4:
+				if (config.targetComponent) {
+					try {
+						test.puup;
+					} catch (err) { }
+					targetComponentId = config.targetComponent.id;
+					config.targetComponentId = targetComponentId;
+					delete config.targetComponent;
+				}
 
+				// link to START node
+				setLinkToDefinition(config, targetComponentId);
 
 				// select component
 				let tabs = {};
@@ -156,10 +225,12 @@
 						componentNodes[node.id] = node;
 					}
 				});
-				if (!config.targetComponent) {
+
+				if (!targetComponentId) {
 					// Add a nice "empty selection" option
 					$('<option value="choose" label="---"></option>').appendTo($("#node-input-selected"));
 				}
+
 				for (let z in tabs) {
 					let tab = tabs[z];
 					let optionGroup = $('<optgroup label="' + tab.label + '"></optgroup>').appendTo($("#node-input-selected"));
@@ -170,8 +241,8 @@
 						optionGroup.append(option);
 					}
 				}
-				if (config.targetComponent) {
-					$("#node-input-selected").val(config.targetComponent.id);
+				if (targetComponentId) {
+					$("#node-input-selected").val(targetComponentId);
 				}
 				$("#node-input-selected").change(function () {
 					let emptyOption = $("#node-input-selected option[value='choose']");
@@ -189,6 +260,7 @@
 					}
 				});
 
+				// status
 				var statusCtrl = $('#node-input-statuz');
 				statusCtrl.typedInput({
 					default: this.statuzType || "str",
@@ -265,46 +337,47 @@
 				this.observer.observe(document.querySelector('#node-input-parameter-container'))
 
 				$("#node-input-selected").change();
+
+				// Handle output ports depending on number of componet flow's return nodes.
+				if (targetComponentId) {
+					let node = this
+					let oldLabels = [...node.outLabels]
+					let newLabels = []
+
+					let foundReturnNodes = {}
+					findReturnNodes(targetComponentId, foundReturnNodes);
+					for (let key in foundReturnNodes) {
+						let retNode = foundReturnNodes[key]
+						if (retNode.mode && retNode.mode == "separate") {
+							newLabels.push(retNode.name || key)
+						} else {
+							if (newLabels.length == 0 || newLabels[0] != "default") {
+								newLabels.splice(0, 0, "default")
+							}
+						}
+					}
+					let diff = newLabels.length != oldLabels.length;
+					// check labels for changes
+					if (!diff) {
+						for (let i in newLabels) {
+							if (newLabels[i] != oldLabels[i]) {
+								diff = true;
+								break;
+							}
+						}
+					}
+					if (diff) {
+						$("#output-alert").show()
+					} else {
+						$("#output-alert").hide()
+					}
+				}
 			} catch (err) {
 				console.trace(err)
 				console.error(err.stack);
 				throw err;
 			}
 
-			// Handle output ports depending on number of componet flow's return nodes.
-			if (this.targetComponent) {
-				let node = this
-				let oldLabels = [...node.outLabels]
-				let newLabels = []
-
-				let foundReturnNodes = {}
-				findReturnNodes(node.targetComponent.id, foundReturnNodes)
-				for (let key in foundReturnNodes) {
-					let retNode = foundReturnNodes[key]
-					if (retNode.mode && retNode.mode == "separate") {
-						newLabels.push(retNode.name || key)
-					} else {
-						if (newLabels.length == 0 || newLabels[0] != "default") {
-							newLabels.splice(0, 0, "default")
-						}
-					}
-				}
-				let diff = newLabels.length != oldLabels.length;
-				// check labels for changes
-				if (!diff) {
-					for (let i in newLabels) {
-						if (newLabels[i] != oldLabels[i]) {
-							diff = true;
-							break;
-						}
-					}
-				}
-				if (diff) {
-					$("#output-alert").show()
-				} else {
-					$("#output-alert").hide()
-				}
-			}
 		},
 		oneditsave: function () {
 			var node = this;
@@ -318,31 +391,27 @@
 				this.statuzType = $("#node-input-statuz").typedInput('type');
 
 				// get target node 
-				node.targetComponent = null;
+				node.targetComponentId = selectedComponentId;
+				let targetComponent;
 				RED.nodes.eachNode(function (n) {
 					if (n.id == selectedComponentId) {
-						node.targetComponent = {
-							id: n.id,
-							name: n.name,
-							api: n.api
-						};
+						targetComponent = n;
 					}
 				});
 
-				if (node.targetComponent == null) {
+				if (targetComponent == null) {
 					throw "could not find target node for ID '" + selectedComponentId + "'";
 				}
 
 				// save parameters from list
 				var params = $("#node-input-parameter-container").editableList('items');
 				node.paramSources = {};
-				node.targetComponent.api.forEach(function (p) {
-					node.paramSources[p.name] = $.extend({}, p);
+				targetComponent.api.forEach(function (p) {
+					node.paramSources[p.name] = { name: p.name };
 				});
 				params.each(function (i) {
 					let item = $(this);
 					let name = item.find(".node-input-property-name").text();
-					let type = item.find(".node-input-property-type").text();
 					let source = item.find(".node-input-property-source input").typedInput('value');
 					let sourceType = item.find(".node-input-property-source input").typedInput('type');
 					let param = node.paramSources[name];
@@ -360,7 +429,7 @@
 
 			// Handle output ports depending on number of componet flow's return nodes.
 			let foundReturnNodes = {}
-			findReturnNodes(node.targetComponent.id, foundReturnNodes)
+			findReturnNodes(node.targetComponentId, foundReturnNodes)
 			node.outLabels = []
 			for (let key in foundReturnNodes) {
 				let retNode = foundReturnNodes[key]

--- a/components/run-component.js
+++ b/components/run-component.js
@@ -16,57 +16,73 @@ module.exports = function (RED) {
       }
 
       // target node's id (component in) to start flow
-      msg._comp.target = node.targetComponent.id;
+      msg._comp.target = node.targetComponentId;
+      let targetComponent = RED.nodes.getNode(node.targetComponentId);
+      let usecontext = targetComponent.usecontext;
+
       // push my ID onto the stack - the next return will come back to me
-      let context = {}; // context lives only until the next return node
-      msg._comp.stack.push({ callerId: node.id, targetId: node.targetComponent.id, context });
-      if (msg._comp.stack.length > 1) {
-        // connect to parent context
-        context._parent = msg._comp.stack.slice(-2)[0].context;
+      let stackEntry = { callerId: node.id, targetId: node.targetComponentId }
+      let context;
+      if (usecontext) {
+        context = {}; // context lives only until the next return node
+        if (msg._comp.stack.length > 1) {
+          // connect to parent context
+          context._parent = msg._comp.stack.slice(-2)[0].context;
+        }
+        stackEntry.context = context;
       }
+      msg._comp.stack.push(stackEntry);
 
       // setup msg from parameters
       let validationErrors = {}
-      for (var paramName in node.paramSources) {
+      // we read the list from the current targetComponent, as it might have changed without touching the RUN node.
+      // That means, that some parameters are not reflected or changed in the paramSources.
+      // That also means, that the RUN node should only keep track of: name, source, sourceType
+      for (var paramIndex in targetComponent.api) {
+        let paramDef = targetComponent.api[paramIndex];
+        let paramName = paramDef.name;
         let paramSource = node.paramSources[paramName];
-        let sourceType = paramSource.sourceType;
         let val = null;
-        // make sure, the user entered a valid source
+
+        // If this RUN node has not yet a source definiton (was not touched after an API change), we just check for required params.
         if (!paramSource) {
-          validationErrors[paramName] = "missing source. please set the parameter to a valid input"
+          if (paramDef.required) {
+            validationErrors[paramName] = "missing source. please set the parameter to a valid input"
+          }
+          continue; // more cheks not possible if we have no paramSource here.
         }
+
         // an empty, optional parameter is evaluated only, if the source type is "string".
         // In that case, the parameter is set(!). It is not put into the message in all other cases.
-        if (paramSource.source && paramSource.source.length > 0 || sourceType == "str") {
+        if (paramSource.source && paramSource.source.length > 0 || paramSource.sourceType == "str") {
           val = RED.util.evaluateNodeProperty(paramSource.source, paramSource.sourceType, node, msg);
         }
         if (val == null || val == undefined) {
-          if (paramSource.required) {
-            node.status({ fill: "red", shape: "ring", text: RED._("components.label.required") + ": '" + paramSource.name + "'" });
-            validationErrors[paramName] = RED._("components.message.missingProperty", { parameter: paramSource.name });
+          if (paramDef.required) {
+            validationErrors[paramName] = RED._("components.message.missingProperty", { parameter: paramName });
           }
         } else {
           // validate types
           let type = typeof (val)
-          switch (paramSource.type) {
+          switch (paramDef.type) {
             case "num": {
               if (type != "number") {
                 validationErrors[paramName] = RED._("components.message.validationError",
-                  { parameter: paramSource.name, expected: paramSource.type, invalidType: type, value: val });
+                  { parameter: paramName, expected: paramDef.type, invalidType: type, value: val });
               }
               break;
             }
             case "string": {
               if (type != "string") {
                 validationErrors[paramName] = RED._("components.message.validationError",
-                  { parameter: paramSource.name, expected: paramSource.type, invalidType: type, value: val });
+                  { parameter: paramName, expected: paramDef.type, invalidType: type, value: val });
               }
               break;
             }
             case "boolean": {
               if (type != "boolean") {
                 validationErrors[paramName] = RED._("components.message.validationError",
-                  { parameter: paramSource.name, expected: paramSource.type, invalidType: type, value: val });
+                  { parameter: paramName, expected: paramDef.type, invalidType: type, value: val });
               }
               break;
             }
@@ -78,7 +94,7 @@ module.exports = function (RED) {
               } catch (err) {
                 console.error("invalid json", val)
                 validationErrors[paramName] = RED._("components.message.jsonValidationError",
-                  { parameter: paramSource.name, value: val });
+                  { parameter: paramName, value: val });
               }
               break;
             }
@@ -87,20 +103,25 @@ module.exports = function (RED) {
               break;
           }
         }
-        if (paramSource.global) {
-          msg[paramSource.name] = val;
+        if (usecontext && paramDef.contextOption) {
+          // local param
+          context[paramName] = val;
         } else {
-          context[paramSource.name] = val;
+          msg[paramName] = val;
         }
       }
-      if (Object.keys(validationErrors).length > 0) {
-        console.error("validation error", validationErrors);
-        node.error("validation error\n" + JSON.stringify(validationErrors));
-      }
-      msg.component = context; // use the new context as "component"
 
-      // send event
-      componentsEmitter.emit(EVENT_START_FLOW + "-" + node.targetComponent.id, msg);
+      if (usecontext) {
+        msg.component = context;
+      }
+
+      if (Object.keys(validationErrors).length > 0) {
+        node.status({ fill: "red", shape: "ring", text: RED._("components.message.hasValidationErrors") });
+        node.error({ validationErrors: validationErrors });
+      } else {
+        // send event
+        componentsEmitter.emit(EVENT_START_FLOW + "-" + node.targetComponentId, msg);
+      }
     } catch (err) {
       console.trace(err)
       node.error(err)
@@ -119,13 +140,13 @@ module.exports = function (RED) {
     RED.nodes.createNode(this, config);
 
     var node = this;
-    node.targetComponent = config.targetComponent;
+    node.targetComponentId = config.targetComponentId || config.targetComponent.id;
     node.paramSources = config.paramSources;
     node.statuz = config.statuz;
     node.statuzType = config.statuzType;
     node.outLabels = config.outLabels;
 
-    if (!node.targetComponent || !node.targetComponent.id) {
+    if (!node.targetComponentId) {
       node.error(RED._("components.message.componentNotConnected"))
       node.status({ fill: "red", shape: "dot", text: RED._("components.message.componentNotConnected") })
     }
@@ -162,7 +183,8 @@ module.exports = function (RED) {
       let stack = msg._comp.stack
       let returnNode = msg._comp.returnNode;
       let lastEntry = stack.slice(-1)[0];
-      let inOnlyScenario = !returnNode && lastEntry.targetId == node.targetComponent.id;
+      let usecontext = lastEntry.context ? true : false;
+      let inOnlyScenario = !returnNode && lastEntry.targetId == node.targetComponentId;
       let broadcastScenario = returnNode && returnNode.broadcast;
       let defaultScenario = returnNode && returnNode.callerId == config.id
       if (inOnlyScenario || broadcastScenario || defaultScenario) {
@@ -172,7 +194,7 @@ module.exports = function (RED) {
         if (stack.length == 0) {
           // stack is empty, so we are done.
           delete msg._comp; // -> following event listeners (component nodes) won't be able to handle this event.
-          if (inOnlyScenario) {
+          if (usecontext && !inOnlyScenario) {
             /*
             remove the component part, if we are in a regular flow (with a return node).
             If we are in a in-only scenario, we keep the msg.component alive. 
@@ -184,8 +206,14 @@ module.exports = function (RED) {
           }
         } else {
           // more on the stack, restore last context
-          let lastEntry = stack.slice(-1)[0];
-          msg.component = lastEntry.context;
+          if (usecontext) {
+            let lastEntry = stack.slice(-1)[0];
+            if (lastEntry.context) {
+              msg.component = lastEntry.context;
+            } else {
+              delete msg.component; // parent has no context (probably usecontext = false!)
+            }
+          }
         }
 
         // find outport
@@ -208,8 +236,6 @@ module.exports = function (RED) {
       }
     }
     componentsEmitter.on(EVENT_RETURN_FLOW + "-" + node.id, returnFromFlowHandler);
-    // global event for broadcasts of in-only flows (no return node)
-    componentsEmitter.on(EVENT_RETURN_FLOW, returnFromFlowHandler);
 
     /*
     if (isInvalidInSubflow(RED, node) == true) {
@@ -225,11 +251,12 @@ module.exports = function (RED) {
     });
 
     this.on("input", function (msg) {
-      if (!node.targetComponent || !node.targetComponent.id) {
+      if (!node.targetComponentId) {
         node.error(RED._("components.message.componentNotConnected"))
         node.status({ fill: "red", shape: "dot", text: RED._("components.message.componentNotConnected") })
         return
       }
+
       node.status({ fill: "green", shape: "ring", text: RED._("components.message.running") });
       sendStartFlow(msg, node);
     });

--- a/components/test/unconnected_spec.js
+++ b/components/test/unconnected_spec.js
@@ -59,16 +59,4 @@ describe('unconnected ', function () {
         });
     });
 
-    it('run nodes should throw an error', function (done) {
-        helper.load([componentStart, componentReturn, runComponent], flowWithUnconnectedInNode, {}, function () {
-            const run01 = helper.getNode('run01')
-            run01.error.should.be.called()
-
-            run01.on('input', () => {
-                run01.error.should.be.called()
-                done();
-            });
-            run01.receive({ test: true });
-        });
-    });
 });

--- a/components/uitest/editor_spec.js
+++ b/components/uitest/editor_spec.js
@@ -1,0 +1,88 @@
+var puppeteer = require("puppeteer");
+var http = require('http');
+var express = require("express");
+var RED = require("node-red");
+
+let server;
+
+describe('nested components in the admin UI', function () {
+
+    before(function (done) {
+        // Create an Express app
+        const app = express();
+
+        // Add a simple route for static content served from 'public'
+        app.use("/", express.static("public"));
+
+        // Create a server
+        server = http.createServer(app);
+
+        // Create the settings object - see default settings.js file for other options
+        var settings = {
+            httpAdminRoot: "/red",
+            httpNodeRoot: "/api",
+            userDir: __dirname,
+            flowFile: "flows.json",
+            functionGlobalContext: {}    // enables global context
+        };
+
+        // Initialise the runtime with a server and settings
+        RED.init(server, settings);
+
+        // Serve the editor UI from /red
+        app.use(settings.httpAdminRoot, RED.httpAdmin);
+
+        // Serve the http nodes UI from /api
+        app.use(settings.httpNodeRoot, RED.httpNode);
+
+        server.listen(8000);
+
+        // Start the runtime
+        RED.start();
+
+        done();
+    });
+
+    after(function (done) {
+        RED.stop();
+        server.close();
+        done();
+    });
+
+    it('should basically work', function (done) {
+        (async () => {
+            const browser = await puppeteer.launch({ defaultViewport: { width: 1280, height: 1024 } });
+            const page = await browser.newPage();
+            await page.goto("http://localhost:8000/red/");
+            await page.waitForSelector("div .red-ui-tabs-search.red-ui-tab-button", { visible: true });
+            await page.screenshot({ path: 'node-red-admin-ui.png' });
+
+            // drag node
+            let elm = await (await page.waitForSelector("[id='19eab3c2.0c8d8c']", { visible: true }));
+            let bounding_box = await elm.boundingBox();
+            let x = bounding_box.x + bounding_box.width / 2;
+            let y = bounding_box.y + bounding_box.height / 2;
+            await page.mouse.move(x, y);
+            await page.mouse.down();
+            await page.waitForTimeout(50);
+            await page.mouse.move(x + 100, y, { steps: 10 });
+            await page.waitForTimeout(50);
+            await page.mouse.up();
+            await page.waitForTimeout(50);
+
+            await page.screenshot({ path: 'after-drag.png' });
+
+
+            await page.mouse.down();
+            await page.mouse.up();
+            await page.mouse.down();
+            await page.mouse.up();
+
+            await page.screenshot({ path: 'after-click.png' });
+
+
+            await browser.close();
+            done();
+        })()
+    }).timeout(20000);
+});

--- a/components/uitest/flows.json
+++ b/components/uitest/flows.json
@@ -18,8 +18,7 @@
         "type": "tab",
         "label": "errors",
         "disabled": true,
-        "info": "",
-        "env": []
+        "info": ""
     },
     {
         "id": "aa8d4fd1ad84c1f0",
@@ -33,8 +32,14 @@
         "type": "tab",
         "label": "in-only & broadcast",
         "disabled": false,
-        "info": "",
-        "env": []
+        "info": ""
+    },
+    {
+        "id": "30c0d1a0cd4cfe1d",
+        "type": "tab",
+        "label": "context",
+        "disabled": false,
+        "info": ""
     },
     {
         "id": "577a607a.ae90e",
@@ -248,27 +253,32 @@
             {
                 "name": "name1",
                 "type": "string",
-                "required": true
+                "required": true,
+                "global": false
             },
             {
                 "name": "Das ist ein längerer",
                 "type": "json",
-                "required": true
+                "required": true,
+                "global": false
             },
             {
                 "name": "number",
                 "type": "number",
-                "required": true
+                "required": true,
+                "global": false
             },
             {
                 "name": "bool",
                 "type": "boolean",
-                "required": true
+                "required": true,
+                "global": false
             },
             {
                 "name": "sdfsdfdfsd",
                 "type": "any",
-                "required": true
+                "required": true,
+                "global": false
             }
         ],
         "x": 130,
@@ -285,7 +295,7 @@
         "z": "22d80fc6.ada47",
         "name": "ret 01a",
         "mode": "default",
-        "x": 670,
+        "x": 650,
         "y": 460,
         "wires": []
     },
@@ -450,70 +460,30 @@
         "type": "component",
         "z": "22d80fc6.ada47",
         "name": "run 01",
-        "targetComponent": {
-            "id": "dcdfa483.b6b2d8",
-            "name": "Component 1",
-            "api": [
-                {
-                    "name": "name1",
-                    "type": "string",
-                    "required": true
-                },
-                {
-                    "name": "Das ist ein längerer",
-                    "type": "json",
-                    "required": true
-                },
-                {
-                    "name": "number",
-                    "type": "number",
-                    "required": true
-                },
-                {
-                    "name": "bool",
-                    "type": "boolean",
-                    "required": true
-                },
-                {
-                    "name": "sdfsdfdfsd",
-                    "type": "any",
-                    "required": true
-                }
-            ]
-        },
+        "targetComponentId": "dcdfa483.b6b2d8",
         "paramSources": {
             "name1": {
                 "name": "name1",
-                "type": "string",
-                "required": true,
                 "source": "\"Test\"",
                 "sourceType": "jsonata"
             },
             "Das ist ein längerer": {
                 "name": "Das ist ein längerer",
-                "type": "json",
-                "required": true,
                 "source": "[\"a\", \"b\"]",
                 "sourceType": "json"
             },
             "number": {
                 "name": "number",
-                "type": "number",
-                "required": true,
                 "source": "4",
                 "sourceType": "json"
             },
             "bool": {
                 "name": "bool",
-                "type": "boolean",
-                "required": true,
                 "source": "true",
                 "sourceType": "bool"
             },
             "sdfsdfdfsd": {
                 "name": "sdfsdfdfsd",
-                "type": "any",
-                "required": true,
                 "source": "{}",
                 "sourceType": "json"
             }
@@ -638,22 +608,7 @@
         "type": "component",
         "z": "5d0725e9aadb00ed",
         "name": "run",
-        "targetComponent": {
-            "id": "4805cfb8e105bf51",
-            "name": "Issue 25",
-            "api": [
-                {
-                    "name": "must",
-                    "type": "any",
-                    "required": true
-                },
-                {
-                    "name": "could2",
-                    "type": "any",
-                    "required": false
-                }
-            ]
-        },
+        "targetComponentId": "4805cfb8e105bf51",
         "paramSources": {
             "must": {
                 "name": "must",
@@ -822,11 +777,7 @@
         "type": "component",
         "z": "5d0725e9aadb00ed",
         "name": "run 04",
-        "targetComponent": {
-            "id": "c58cbb4f.4a7a98",
-            "name": "Component 4",
-            "api": []
-        },
+        "targetComponentId": "c58cbb4f.4a7a98",
         "paramSources": {},
         "statuz": "",
         "statuzType": "str",
@@ -1219,7 +1170,6 @@
         "persist": false,
         "proxy": "",
         "authType": "",
-        "senderr": false,
         "x": 330,
         "y": 980,
         "wires": [
@@ -1723,10 +1673,10 @@
                 "name": "prop",
                 "type": "json",
                 "required": true,
-                "global": false
+                "contextOption": true
             }
         ],
-        "node_is_not_connected": false,
+        "usecontext": true,
         "x": 110,
         "y": 280,
         "wires": [
@@ -1740,24 +1690,10 @@
         "type": "component",
         "z": "aa8d4fd1ad84c1f0",
         "name": "",
-        "targetComponent": {
-            "id": "a6a8a672c69ba580",
-            "name": "handle",
-            "api": [
-                {
-                    "name": "prop",
-                    "type": "json",
-                    "required": true,
-                    "global": false
-                }
-            ]
-        },
+        "targetComponentId": "a6a8a672c69ba580",
         "paramSources": {
             "prop": {
                 "name": "prop",
-                "type": "json",
-                "required": true,
-                "global": false,
                 "source": "payload.1",
                 "sourceType": "msg"
             }
@@ -1855,24 +1791,10 @@
         "type": "component",
         "z": "aa8d4fd1ad84c1f0",
         "name": "",
-        "targetComponent": {
-            "id": "a6a8a672c69ba580",
-            "name": "handle",
-            "api": [
-                {
-                    "name": "prop",
-                    "type": "json",
-                    "required": true,
-                    "global": false
-                }
-            ]
-        },
+        "targetComponentId": "a6a8a672c69ba580",
         "paramSources": {
             "prop": {
                 "name": "prop",
-                "type": "json",
-                "required": true,
-                "global": false,
                 "source": "component.child",
                 "sourceType": "msg"
             }
@@ -1950,7 +1872,6 @@
                 "global": false
             }
         ],
-        "node_is_not_connected": false,
         "x": 190,
         "y": 140,
         "wires": [
@@ -2077,7 +1998,6 @@
         "z": "6542e73107b394b8",
         "name": "",
         "mode": "default",
-        "node_is_not_connected": false,
         "component_definitions_are_NOT_allowed_inside_subflows": false,
         "x": 390,
         "y": 360,
@@ -2089,7 +2009,7 @@
         "z": "6542e73107b394b8",
         "name": "broadcast",
         "api": [],
-        "node_is_not_connected": false,
+        "usecontext": true,
         "x": 180,
         "y": 360,
         "wires": [
@@ -2196,5 +2116,194 @@
         "x": 590,
         "y": 140,
         "wires": []
+    },
+    {
+        "id": "f2cee2089b3e32f4",
+        "type": "component_in",
+        "z": "30c0d1a0cd4cfe1d",
+        "name": "context test",
+        "api": [
+            {
+                "name": "local",
+                "type": "string",
+                "required": true,
+                "contextOption": true
+            },
+            {
+                "name": "global",
+                "type": "string",
+                "required": true,
+                "contextOption": false
+            },
+            {
+                "name": "new",
+                "type": "any",
+                "required": true,
+                "contextOption": true
+            },
+            {
+                "name": "more",
+                "type": "any",
+                "required": false,
+                "contextOption": false
+            }
+        ],
+        "usecontext": true,
+        "x": 260,
+        "y": 280,
+        "wires": [
+            [
+                "eb40fac2aaf55e1d",
+                "98717880920f80cd"
+            ]
+        ]
+    },
+    {
+        "id": "eb40fac2aaf55e1d",
+        "type": "component_out",
+        "z": "30c0d1a0cd4cfe1d",
+        "name": "",
+        "mode": "default",
+        "component_definitions_are_NOT_allowed_inside_subflows": false,
+        "x": 550,
+        "y": 280,
+        "wires": []
+    },
+    {
+        "id": "98717880920f80cd",
+        "type": "debug",
+        "z": "30c0d1a0cd4cfe1d",
+        "name": "",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "true",
+        "targetType": "full",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 530,
+        "y": 320,
+        "wires": []
+    },
+    {
+        "id": "964a1a83684e53d4",
+        "type": "component",
+        "z": "30c0d1a0cd4cfe1d",
+        "name": "",
+        "targetComponentId": "f2cee2089b3e32f4",
+        "paramSources": {
+            "local": {
+                "name": "local",
+                "source": "LOKAL",
+                "sourceType": "str"
+            },
+            "global": {
+                "name": "global",
+                "source": "GLOBAL",
+                "sourceType": "str"
+            },
+            "new": {
+                "name": "new",
+                "source": "nix",
+                "sourceType": "str"
+            },
+            "more": {
+                "name": "more",
+                "source": "mehr",
+                "sourceType": "msg"
+            }
+        },
+        "statuz": "",
+        "statuzType": "str",
+        "outputs": 1,
+        "outLabels": [
+            "default"
+        ],
+        "x": 340,
+        "y": 160,
+        "wires": [
+            [
+                "a624eea87150a7ba"
+            ]
+        ]
+    },
+    {
+        "id": "a624eea87150a7ba",
+        "type": "debug",
+        "z": "30c0d1a0cd4cfe1d",
+        "name": "",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "true",
+        "targetType": "full",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 530,
+        "y": 160,
+        "wires": []
+    },
+    {
+        "id": "54443514c513ade4",
+        "type": "catch",
+        "z": "30c0d1a0cd4cfe1d",
+        "name": "",
+        "scope": null,
+        "uncaught": false,
+        "x": 270,
+        "y": 420,
+        "wires": [
+            [
+                "55e62fa1f68fcba7"
+            ]
+        ]
+    },
+    {
+        "id": "55e62fa1f68fcba7",
+        "type": "debug",
+        "z": "30c0d1a0cd4cfe1d",
+        "name": "",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "true",
+        "targetType": "full",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 450,
+        "y": 420,
+        "wires": []
+    },
+    {
+        "id": "0308a944488b3139",
+        "type": "inject",
+        "z": "30c0d1a0cd4cfe1d",
+        "name": "",
+        "props": [
+            {
+                "p": "payload"
+            },
+            {
+                "p": "topic",
+                "vt": "str"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "",
+        "payloadType": "date",
+        "x": 170,
+        "y": 160,
+        "wires": [
+            [
+                "964a1a83684e53d4"
+            ]
+        ]
     }
 ]

--- a/components/uitest/package.json
+++ b/components/uitest/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "node-red-project",
+    "description": "A Node-RED Project",
+    "version": "0.0.1",
+    "private": true,
+    "dependencies": {
+        "node-red-contrib-components": "file:../../"
+    }
+}

--- a/components/uitest/settings.js
+++ b/components/uitest/settings.js
@@ -1,0 +1,486 @@
+/**
+ * This is the default settings file provided by Node-RED.
+ *
+ * It can contain any valid JavaScript code that will get run when Node-RED
+ * is started.
+ *
+ * Lines that start with // are commented out.
+ * Each entry should be separated from the entries above and below by a comma ','
+ *
+ * For more information about individual settings, refer to the documentation:
+ *    https://nodered.org/docs/user-guide/runtime/configuration
+ *
+ * The settings are split into the following sections:
+ *  - Flow File and User Directory Settings
+ *  - Security
+ *  - Server Settings
+ *  - Runtime Settings
+ *  - Editor Settings
+ *  - Node Settings
+ *
+ **/
+
+module.exports = {
+
+/*******************************************************************************
+ * Flow File and User Directory Settings
+ *  - flowFile
+ *  - credentialSecret
+ *  - flowFilePretty
+ *  - userDir
+ *  - nodesDir
+ ******************************************************************************/
+
+    /** The file containing the flows. If not set, defaults to flows_<hostname>.json **/
+    flowFile: 'flows.json',
+
+    /** By default, credentials are encrypted in storage using a generated key. To
+     * specify your own secret, set the following property.
+     * If you want to disable encryption of credentials, set this property to false.
+     * Note: once you set this property, do not change it - doing so will prevent
+     * node-red from being able to decrypt your existing credentials and they will be
+     * lost.
+     */
+    //credentialSecret: "a-secret-key",
+
+    /** By default, the flow JSON will be formatted over multiple lines making
+     * it easier to compare changes when using version control.
+     * To disable pretty-printing of the JSON set the following property to false.
+     */
+    flowFilePretty: true,
+
+    /** By default, all user data is stored in a directory called `.node-red` under
+     * the user's home directory. To use a different location, the following
+     * property can be used
+     */
+    //userDir: '/home/nol/.node-red/',
+
+    /** Node-RED scans the `nodes` directory in the userDir to find local node files.
+     * The following property can be used to specify an additional directory to scan.
+     */
+    //nodesDir: '/home/nol/.node-red/nodes',
+
+/*******************************************************************************
+ * Security
+ *  - adminAuth
+ *  - https
+ *  - httpsRefreshInterval
+ *  - requireHttps
+ *  - httpNodeAuth
+ *  - httpStaticAuth
+ ******************************************************************************/
+
+    /** To password protect the Node-RED editor and admin API, the following
+     * property can be used. See http://nodered.org/docs/security.html for details.
+     */
+    //adminAuth: {
+    //    type: "credentials",
+    //    users: [{
+    //        username: "admin",
+    //        password: "$2a$08$zZWtXTja0fB1pzD4sHCMyOCMYz2Z6dNbM6tl8sJogENOMcxWV9DN.",
+    //        permissions: "*"
+    //    }]
+    //},
+
+    /** The following property can be used to enable HTTPS
+     * This property can be either an object, containing both a (private) key
+     * and a (public) certificate, or a function that returns such an object.
+     * See http://nodejs.org/api/https.html#https_https_createserver_options_requestlistener
+     * for details of its contents.
+     */
+
+    /** Option 1: static object */
+    //https: {
+    //  key: require("fs").readFileSync('privkey.pem'),
+    //  cert: require("fs").readFileSync('cert.pem')
+    //},
+
+    /** Option 2: function that returns the HTTP configuration object */
+    // https: function() {
+    //     // This function should return the options object, or a Promise
+    //     // that resolves to the options object
+    //     return {
+    //         key: require("fs").readFileSync('privkey.pem'),
+    //         cert: require("fs").readFileSync('cert.pem')
+    //     }
+    // },
+
+    /** If the `https` setting is a function, the following setting can be used
+     * to set how often, in hours, the function will be called. That can be used
+     * to refresh any certificates.
+     */
+    //httpsRefreshInterval : 12,
+
+    /** The following property can be used to cause insecure HTTP connections to
+     * be redirected to HTTPS.
+     */
+    //requireHttps: true,
+
+    /** To password protect the node-defined HTTP endpoints (httpNodeRoot),
+     * including node-red-dashboard, or the static content (httpStatic), the
+     * following properties can be used.
+     * The `pass` field is a bcrypt hash of the password.
+     * See http://nodered.org/docs/security.html#generating-the-password-hash
+     */
+    //httpNodeAuth: {user:"user",pass:"$2a$08$zZWtXTja0fB1pzD4sHCMyOCMYz2Z6dNbM6tl8sJogENOMcxWV9DN."},
+    //httpStaticAuth: {user:"user",pass:"$2a$08$zZWtXTja0fB1pzD4sHCMyOCMYz2Z6dNbM6tl8sJogENOMcxWV9DN."},
+
+/*******************************************************************************
+ * Server Settings
+ *  - uiPort
+ *  - uiHost
+ *  - apiMaxLength
+ *  - httpServerOptions
+ *  - httpAdminRoot
+ *  - httpAdminMiddleware
+ *  - httpNodeRoot
+ *  - httpNodeCors
+ *  - httpNodeMiddleware
+ *  - httpStatic
+ ******************************************************************************/
+
+    /** the tcp port that the Node-RED web server is listening on */
+    uiPort: process.env.PORT || 1880,
+
+    /** By default, the Node-RED UI accepts connections on all IPv4 interfaces.
+     * To listen on all IPv6 addresses, set uiHost to "::",
+     * The following property can be used to listen on a specific interface. For
+     * example, the following would only allow connections from the local machine.
+     */
+    //uiHost: "127.0.0.1",
+
+    /** The maximum size of HTTP request that will be accepted by the runtime api.
+     * Default: 5mb
+     */
+    //apiMaxLength: '5mb',
+
+    /** The following property can be used to pass custom options to the Express.js
+     * server used by Node-RED. For a full list of available options, refer
+     * to http://expressjs.com/en/api.html#app.settings.table
+     */
+    //httpServerOptions: { },
+
+    /** By default, the Node-RED UI is available at http://localhost:1880/
+     * The following property can be used to specify a different root path.
+     * If set to false, this is disabled.
+     */
+    //httpAdminRoot: '/admin',
+
+    /** The following property can be used to add a custom middleware function
+     * in front of all admin http routes. For example, to set custom http
+     * headers. It can be a single function or an array of middleware functions.
+     */
+    // httpAdminMiddleware: function(req,res,next) {
+    //    // Set the X-Frame-Options header to limit where the editor
+    //    // can be embedded
+    //    //res.set('X-Frame-Options', 'sameorigin');
+    //    next();
+    // },
+
+
+    /** Some nodes, such as HTTP In, can be used to listen for incoming http requests.
+     * By default, these are served relative to '/'. The following property
+     * can be used to specifiy a different root path. If set to false, this is
+     * disabled.
+     */
+    //httpNodeRoot: '/red-nodes',
+
+    /** The following property can be used to configure cross-origin resource sharing
+     * in the HTTP nodes.
+     * See https://github.com/troygoode/node-cors#configuration-options for
+     * details on its contents. The following is a basic permissive set of options:
+     */
+    //httpNodeCors: {
+    //    origin: "*",
+    //    methods: "GET,PUT,POST,DELETE"
+    //},
+
+    /** If you need to set an http proxy please set an environment variable
+     * called http_proxy (or HTTP_PROXY) outside of Node-RED in the operating system.
+     * For example - http_proxy=http://myproxy.com:8080
+     * (Setting it here will have no effect)
+     * You may also specify no_proxy (or NO_PROXY) to supply a comma separated
+     * list of domains to not proxy, eg - no_proxy=.acme.co,.acme.co.uk
+     */
+
+    /** The following property can be used to add a custom middleware function
+     * in front of all http in nodes. This allows custom authentication to be
+     * applied to all http in nodes, or any other sort of common request processing.
+     * It can be a single function or an array of middleware functions.
+     */
+    //httpNodeMiddleware: function(req,res,next) {
+    //    // Handle/reject the request, or pass it on to the http in node by calling next();
+    //    // Optionally skip our rawBodyParser by setting this to true;
+    //    //req.skipRawBodyParser = true;
+    //    next();
+    //},
+
+    /** When httpAdminRoot is used to move the UI to a different root path, the
+     * following property can be used to identify a directory of static content
+     * that should be served at http://localhost:1880/.
+     */
+    //httpStatic: '/home/nol/node-red-static/',
+
+/*******************************************************************************
+ * Runtime Settings
+ *  - lang
+ *  - logging
+ *  - contextStorage
+ *  - exportGlobalContextKeys
+ *  - externalModules
+ ******************************************************************************/
+
+     /** Uncomment the following to run node-red in your preferred language.
+      * Available languages include: en-US (default), ja, de, zh-CN, zh-TW, ru, ko
+      * Some languages are more complete than others.
+      */
+     // lang: "de",
+
+     /** Configure the logging output */
+     logging: {
+         /** Only console logging is currently supported */
+         console: {
+             /** Level of logging to be recorded. Options are:
+              * fatal - only those errors which make the application unusable should be recorded
+              * error - record errors which are deemed fatal for a particular request + fatal errors
+              * warn - record problems which are non fatal + errors + fatal errors
+              * info - record information about the general running of the application + warn + error + fatal errors
+              * debug - record information which is more verbose than info + info + warn + error + fatal errors
+              * trace - record very detailed logging + debug + info + warn + error + fatal errors
+              * off - turn off all logging (doesn't affect metrics or audit)
+              */
+             level: "info",
+             /** Whether or not to include metric events in the log output */
+             metrics: false,
+             /** Whether or not to include audit events in the log output */
+             audit: false
+         }
+     },
+
+     /** Context Storage
+      * The following property can be used to enable context storage. The configuration
+      * provided here will enable file-based context that flushes to disk every 30 seconds.
+      * Refer to the documentation for further options: https://nodered.org/docs/api/context/
+      */
+     //contextStorage: {
+     //    default: {
+     //        module:"localfilesystem"
+     //    },
+     //},
+
+     /** `global.keys()` returns a list of all properties set in global context.
+      * This allows them to be displayed in the Context Sidebar within the editor.
+      * In some circumstances it is not desirable to expose them to the editor. The
+      * following property can be used to hide any property set in `functionGlobalContext`
+      * from being list by `global.keys()`.
+      * By default, the property is set to false to avoid accidental exposure of
+      * their values. Setting this to true will cause the keys to be listed.
+      */
+     exportGlobalContextKeys: false,
+
+     /** Configure how the runtime will handle external npm modules.
+      * This covers:
+      *  - whether the editor will allow new node modules to be installed
+      *  - whether nodes, such as the Function node are allowed to have their
+      * own dynamically configured dependencies.
+      * The allow/denyList options can be used to limit what modules the runtime
+      * will install/load. It can use '*' as a wildcard that matches anything.
+      */
+     externalModules: {
+         // autoInstall: false,   /** Whether the runtime will attempt to automatically install missing modules */
+         // autoInstallRetry: 30, /** Interval, in seconds, between reinstall attempts */
+         // palette: {              /** Configuration for the Palette Manager */
+         //     allowInstall: true, /** Enable the Palette Manager in the editor */
+         //     allowUpload: true,  /** Allow module tgz files to be uploaded and installed */
+         //     allowList: [],
+         //     denyList: []
+         // },
+         // modules: {              /** Configuration for node-specified modules */
+         //     allowInstall: true,
+         //     allowList: [],
+         //     denyList: []
+         // }
+     },
+
+
+/*******************************************************************************
+ * Editor Settings
+ *  - disableEditor
+ *  - editorTheme
+ ******************************************************************************/
+
+    /** The following property can be used to disable the editor. The admin API
+     * is not affected by this option. To disable both the editor and the admin
+     * API, use either the httpRoot or httpAdminRoot properties
+     */
+    //disableEditor: false,
+
+    /** Customising the editor
+     * See https://nodered.org/docs/user-guide/runtime/configuration#editor-themes
+     * for all available options.
+     */
+    editorTheme: {
+        /** The following property can be used to set a custom theme for the editor.
+         * See https://github.com/node-red-contrib-themes/theme-collection for
+         * a collection of themes to chose from.
+         */
+        //theme: "",
+        palette: {
+            /** The following property can be used to order the categories in the editor
+             * palette. If a node's category is not in the list, the category will get
+             * added to the end of the palette.
+             * If not set, the following default order is used:
+             */
+            //categories: ['subflows', 'common', 'function', 'network', 'sequence', 'parser', 'storage'],
+        },
+        projects: {
+            /** To enable the Projects feature, set this value to true */
+            enabled: false,
+            workflow: {
+                /** Set the default projects workflow mode.
+                 *  - manual - you must manually commit changes
+                 *  - auto - changes are automatically committed
+                 * This can be overridden per-user from the 'Git config'
+                 * section of 'User Settings' within the editor
+                 */
+                mode: "manual"
+            }
+        },
+        codeEditor: {
+            /** Select the text editor component used by the editor.
+             * Defaults to "ace", but can be set to "ace" or "monaco"
+             */
+            lib: "ace",
+            options: {
+                /** The follow options only apply if the editor is set to "monaco"
+                 *
+                 * theme - must match the file name of a theme in
+                 * packages/node_modules/@node-red/editor-client/src/vendor/monaco/dist/theme
+                 * e.g. "tomorrow-night", "upstream-sunburst", "github", "my-theme"
+                 */
+                theme: "vs",
+                /** other overrides can be set e.g. fontSize, fontFamily, fontLigatures etc.
+                 * for the full list, see https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.istandaloneeditorconstructionoptions.html
+                 */
+                //fontSize: 14,
+                //fontFamily: "Cascadia Code, Fira Code, Consolas, 'Courier New', monospace",
+                //fontLigatures: true,
+            }
+        }
+    },
+
+/*******************************************************************************
+ * Node Settings
+ *  - fileWorkingDirectory
+ *  - functionGlobalContext
+ *  - functionExternalModules
+ *  - nodeMessageBufferMaxLength
+ *  - ui (for use with Node-RED Dashboard)
+ *  - debugUseColors
+ *  - debugMaxLength
+ *  - execMaxBufferSize
+ *  - httpRequestTimeout
+ *  - mqttReconnectTime
+ *  - serialReconnectTime
+ *  - socketReconnectTime
+ *  - socketTimeout
+ *  - tcpMsgQueueSize
+ *  - inboundWebSocketTimeout
+ *  - tlsConfigDisableLocalFiles
+ *  - webSocketNodeVerifyClient
+ ******************************************************************************/
+
+    /** The working directory to handle relative file paths from within the File nodes
+     * defaults to the working directory of the Node-RED process.
+     */
+    //fileWorkingDirectory: "",
+
+    /** Allow the Function node to load additional npm modules directly */
+    functionExternalModules: true,
+
+    /** The following property can be used to set predefined values in Global Context.
+     * This allows extra node modules to be made available with in Function node.
+     * For example, the following:
+     *    functionGlobalContext: { os:require('os') }
+     * will allow the `os` module to be accessed in a Function node using:
+     *    global.get("os")
+     */
+    functionGlobalContext: {
+        // os:require('os'),
+    },
+
+    /** The maximum number of messages nodes will buffer internally as part of their
+     * operation. This applies across a range of nodes that operate on message sequences.
+     * defaults to no limit. A value of 0 also means no limit is applied.
+     */
+    //nodeMessageBufferMaxLength: 0,
+
+    /** If you installed the optional node-red-dashboard you can set it's path
+     * relative to httpNodeRoot
+     * Other optional properties include
+     *  readOnly:{boolean},
+     *  middleware:{function or array}, (req,res,next) - http middleware
+     *  ioMiddleware:{function or array}, (socket,next) - socket.io middleware
+     */
+    //ui: { path: "ui" },
+
+    /** Colourise the console output of the debug node */
+    //debugUseColors: true,
+
+    /** The maximum length, in characters, of any message sent to the debug sidebar tab */
+    debugMaxLength: 1000,
+
+    /** Maximum buffer size for the exec node. Defaults to 10Mb */
+    //execMaxBufferSize: 10000000,
+
+    /** Timeout in milliseconds for HTTP request connections. Defaults to 120s */
+    //httpRequestTimeout: 120000,
+
+    /** Retry time in milliseconds for MQTT connections */
+    mqttReconnectTime: 15000,
+
+    /** Retry time in milliseconds for Serial port connections */
+    serialReconnectTime: 15000,
+
+    /** Retry time in milliseconds for TCP socket connections */
+    //socketReconnectTime: 10000,
+
+    /** Timeout in milliseconds for TCP server socket connections. Defaults to no timeout */
+    //socketTimeout: 120000,
+
+    /** Maximum number of messages to wait in queue while attempting to connect to TCP socket
+     * defaults to 1000
+     */
+    //tcpMsgQueueSize: 2000,
+
+    /** Timeout in milliseconds for inbound WebSocket connections that do not
+     * match any configured node. Defaults to 5000
+     */
+    //inboundWebSocketTimeout: 5000,
+
+    /** To disable the option for using local files for storing keys and
+     * certificates in the TLS configuration node, set this to true.
+     */
+    //tlsConfigDisableLocalFiles: true,
+
+    /** The following property can be used to verify websocket connection attempts.
+     * This allows, for example, the HTTP request headers to be checked to ensure
+     * they include valid authentication information.
+     */
+    //webSocketNodeVerifyClient: function(info) {
+    //    /** 'info' has three properties:
+    //    *   - origin : the value in the Origin header
+    //    *   - req : the HTTP request
+    //    *   - secure : true if req.connection.authorized or req.connection.encrypted is set
+    //    *
+    //    * The function should return true if the connection should be accepted, false otherwise.
+    //    *
+    //    * Alternatively, if this function is defined to accept a second argument, callback,
+    //    * it can be used to verify the client asynchronously.
+    //    * The callback takes three arguments:
+    //    *   - result : boolean, whether to accept the connection or not
+    //    *   - code : if result is false, the HTTP error status to return
+    //    *   - reason: if result is false, the HTTP reason string to return
+    //    */
+    //},
+}

--- a/examples/recursion.json
+++ b/examples/recursion.json
@@ -9,10 +9,10 @@
                 "name": "prop",
                 "type": "json",
                 "required": true,
-                "global": false
+                "contextOption": true
             }
         ],
-        "node_is_not_connected": false,
+        "usecontext": true,
         "x": 110,
         "y": 280,
         "wires": [
@@ -26,24 +26,10 @@
         "type": "component",
         "z": "aa8d4fd1ad84c1f0",
         "name": "",
-        "targetComponent": {
-            "id": "a6a8a672c69ba580",
-            "name": "handle",
-            "api": [
-                {
-                    "name": "prop",
-                    "type": "json",
-                    "required": true,
-                    "global": false
-                }
-            ]
-        },
+        "targetComponentId": "a6a8a672c69ba580",
         "paramSources": {
             "prop": {
                 "name": "prop",
-                "type": "json",
-                "required": true,
-                "global": false,
                 "source": "payload.1",
                 "sourceType": "msg"
             }
@@ -141,24 +127,10 @@
         "type": "component",
         "z": "aa8d4fd1ad84c1f0",
         "name": "",
-        "targetComponent": {
-            "id": "a6a8a672c69ba580",
-            "name": "handle",
-            "api": [
-                {
-                    "name": "prop",
-                    "type": "json",
-                    "required": true,
-                    "global": false
-                }
-            ]
-        },
+        "targetComponentId": "a6a8a672c69ba580",
         "paramSources": {
             "prop": {
                 "name": "prop",
-                "type": "json",
-                "required": true,
-                "global": false,
                 "source": "component.child",
                 "sourceType": "msg"
             }

--- a/package.json
+++ b/package.json
@@ -26,10 +26,12 @@
     "devDependencies": {
         "mocha": "^7.0.1",
         "node-red": "^1.2.2",
-        "node-red-node-test-helper": "^0.2.7"
+        "node-red-node-test-helper": "^0.2.7",
+        "puppeteer": "^12.0.1"
     },
     "dependencies": {},
     "scripts": {
-        "test": "mocha components/test/*_spec.js"
+        "test": "mocha components/test/*_spec.js",
+        "uitest": "npm --prefix ./components/uitest/ install; cd components/uitest/; mocha *_spec.js"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "node-red-contrib-components",
     "description": "reusable flows with a well defined API. Write components and use them anywhere in your node-red app",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "license": "MIT",
     "author": "Oliver Charlet <oliver.charlet@clarities.de>",
     "repository": {


### PR DESCRIPTION
This is another breaking change, which might need a refactoring of your components.
0.2.2 introduced the local / global context, but that was not such a good idea, as it broke your flows.

After a user request, I decided to go back / forth and change the context as such:
- the (local) context is optional and off by default.
- if the local context option is ON, each parameter has the optional to be local, i.e. to show up in msg.component, which lives only inside the component flow. 
- Parent context is still provided inside nested components.

0.2.4. also has some bugfixes in the editor adn should now fix most of the bugs regarding node validation (connectivity).
